### PR TITLE
KBV:445Updated check controller to perform post for the fraud check

### DIFF
--- a/local.Dockerfile
+++ b/local.Dockerfile
@@ -1,6 +1,6 @@
 FROM node:16.14.2-alpine
 
-ENV PORT 5040
+ENV PORT 5030
 
 WORKDIR /app
 

--- a/src/app/fraud/controllers/check.js
+++ b/src/app/fraud/controllers/check.js
@@ -6,10 +6,13 @@ const {
   },
 } = require("../../../lib/config");
 
-class AddressSearchController extends BaseController {
+class FraudCheckController extends BaseController {
   async saveValues(req, res, callback) {
-    const fraudCheck = await req.axios.get(`${CHECK}`, {
-      session_id: req.session.tokenId,
+    const fraudCheck = await req.axios.post(`${CHECK}`, {}, {
+      headers: {
+        'Content-Type': 'application/application-json',
+        'session_id': req.session.tokenId
+      }
     });
 
     req.session.authParams.authorization_code =
@@ -19,4 +22,4 @@ class AddressSearchController extends BaseController {
   }
 }
 
-module.exports = AddressSearchController;
+module.exports = FraudCheckController;

--- a/src/app/fraud/controllers/check.js
+++ b/src/app/fraud/controllers/check.js
@@ -8,15 +8,13 @@ const {
 
 class FraudCheckController extends BaseController {
   async saveValues(req, res, callback) {
-    const fraudCheck = await req.axios.post(`${CHECK}`, {}, {
+    await req.axios.post(`${CHECK}`, {}, {
       headers: {
         'Content-Type': 'application/application-json',
         'session_id': req.session.tokenId
       }
     });
 
-    req.session.authParams.authorization_code =
-      fraudCheck.data?.authorization_code;
 
     return super.saveValues(req, res, callback);
   }

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -5,16 +5,16 @@ module.exports = {
     BASE_URL: process.env.API_BASE_URL || "http://localhost:5007/",
     PATHS: {
       AUTHORIZE: "session",
-      CHECK: "check",
+      CHECK: "identity-check",
     },
   },
   APP: {
-    BASE_URL: process.env.EXTERNAL_WEBSITE_HOST || "http://localhost:5040",
+    BASE_URL: process.env.EXTERNAL_WEBSITE_HOST || "http://localhost:5030",
     PATHS: {
       FRAUD: "/",
     },
   },
-  PORT: process.env.PORT || 5040,
+  PORT: process.env.PORT || 5030,
   SESSION_SECRET: process.env.SESSION_SECRET,
   REDIS: {
     SESSION_URL: process.env.REDIS_SESSION_URL,

--- a/test/mocks/mappings/fraud.json
+++ b/test/mocks/mappings/fraud.json
@@ -37,19 +37,26 @@
       "scenarioName": "fraud-success",
       "requiredScenarioState": "FraudCheck",
       "request": {
-        "method": "GET",
-        "urlPath": "/check",
+        "method": "POST",
+        "urlPath": "/identity-check",
         "headers": {
           "x-scenario-id": {
             "equalTo": "fraud-success"
+          },
+          "session_id": {
+            "equalTo": "ABADCAFE"
           }
         }
       },
       "response": {
         "status": 200,
-        "jsonBody": {
-          "authorization_code": "FACEFEED"
-        }
+        "jsonBody":
+          {
+            "success": true,
+            "validationErrors": null,
+            "error": null,
+            "contraIndicators": []
+          }
       }
     }
   ]


### PR DESCRIPTION
Updated check controller to perform post for the fraud check

## Proposed changes

### What changed

Updated check controller to perform post for the fraud check
Updated config and docker file so fraud cri port matches core stub. 

### Why did it change

To allow a fraud journey up to the third party fraud check

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KBV-445](https://govukverify.atlassian.net/browse/KBV-445)

