### PR TITLE
Create a Dockerfile that builds Fraud frontend image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM node:16.14.2-alpine3.15@sha256:38bc06c682ae1f89f4c06a5f40f7a07ae438ca437a2a04cf773e66960b2d75bc AS builder
+
+WORKDIR /app
+
+COPY .yarn ./.yarn
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY /src ./src
+
+RUN yarn install
+RUN yarn build
+
+# 'yarn install --production' does not prune test packages which are necessary
+# to build the app. So delete nod_modules and reinstall only production packages.
+RUN [ "rm", "-rf", "node_modules" ]
+RUN yarn install --production --frozen-lockfile
+
+FROM node:16.14.2-alpine3.15@sha256:38bc06c682ae1f89f4c06a5f40f7a07ae438ca437a2a04cf773e66960b2d75bc AS final
+
+RUN ["apk", "--no-cache", "upgrade"]
+RUN ["apk", "add", "--no-cache", "tini"]
+
+WORKDIR /app
+
+# Copy in compile assets and deps from build container
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/package.json ./
+COPY --from=builder /app/yarn.lock ./
+COPY --from=builder /app/src ./src
+
+
+ENV PORT 8080
+EXPOSE $PORT
+
+ENTRYPOINT ["tini", "--"]
+
+CMD ["yarn", "start"]


### PR DESCRIPTION

## Proposed changes
Added Dockerfile that builds Fraud frontend image

### What changed

Please see above

### Why did it change

To facilitate fraud build into Fargate



### Issue tracking

- [KBV-447](https://govukverify.atlassian.net/browse/KBV-447)
- [KBV-454](https://govukverify.atlassian.net/browse/KBV-454)


## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed

