### PR TITLE
LIME-86 - Updating packag.json to point towards latest common-express…

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "cfenv": "1.2.4",
     "connect-dynamodb": "^2.0.4",
     "copyfiles": "2.4.1",
-    "di-ipv-cri-common-express": "alphagov/di-ipv-cri-common-express.git#v0.0.22",
+    "di-ipv-cri-common-express": "alphagov/di-ipv-cri-common-express.git#v0.0.23",
     "dotenv": "16.0.1",
     "express": "4.18.1",
     "express-async-errors": "3.1.1",


### PR DESCRIPTION
### What changed

Updated di-ipv-common-express value in package.json

### Why did it change

So that fraud-front end uses latest version of the common express repo to include latest accessibility fixes 
