### PR TITLE
feat: Add config for English and Welsh translations

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -65,6 +65,11 @@ const { app, router } = setup({
   },
   publicDirs: ["../dist/public"],
   publicImagesDirs: ["../dist/public/images"],
+  translation: {
+    allowedLangs: ["en", "cy"],
+    fallbackLang: ["en"],
+    cookie: { name: "lng" },
+  },
   views: [
     path.resolve(
       path.dirname(require.resolve("di-ipv-cri-common-express")),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

- Changed default `i18next` cookie property to `lng` to match [auth team's usage](https://github.com/alphagov/di-authentication-frontend/blob/11bf1617e25e925ab680096f813f9c0d4876792c/src/config/i18next.ts#L8-L11).
- Added allowedLang
- Added fallbackLang

### Why did it change

Aligning the cookies means that when the auth team set a preference for a language, that it is applied in the KBV UI as well.


<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-876](https://govukverify.atlassian.net/browse/OJ-876)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks
