### PR TITLE
OJ-988 - Refer to fraud-api v1

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -364,7 +364,7 @@ Resources:
               Value: !Sub
                 - "https://${APIGatewayId}.execute-api.eu-west-2.amazonaws.com/${Environment}"
                 - APIGatewayId:
-                    Fn::ImportValue: fraud-cri-api-PrivateFraudApiGatewayId
+                    Fn::ImportValue: fraud-cri-api-v1-PrivateFraudApiGatewayId
                   Environment: !Ref Environment
             - Name: EXTERNAL_WEBSITE_HOST
               Value: !GetAtt ApiGwHttpEndpoint.ApiEndpoint


### PR DESCRIPTION
### What changed
- Modified the API_BASE_URL environment variable to refer to the new fraud CRI stack

### Why did it change
- To migrate to the new common stack framework

### Issue tracking
- [OJ-988](https://govukverify.atlassian.net/browse/OJ-988)
