### PR TITLE
Removing-CSLS-Rust: Removing old log subscriptions

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -336,14 +336,6 @@ Resources:
       LogGroupName: !Sub /aws/ecs/${AWS::StackName}-FraudFront-ECS
       RetentionInDays: 14
 
-  ECSAccessLogsGroupSubscriptionFilter:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
-      FilterPattern: ""
-      LogGroupName: !Sub "/aws/ecs/${AWS::StackName}-FraudFront-ECS"
-
   ECSAccessLogsGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter
     Condition: IsNotDevelopment
@@ -522,14 +514,6 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/apigateway/${AWS::StackName}-FraudFront-API-GW-AccessLogs
-
-  APIGWAccessLogsGroupSubscriptionFilter:
-    Type: AWS::Logs::SubscriptionFilter
-    Condition: IsNotDevelopment
-    Properties:
-      DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prod"
-      FilterPattern: ""
-      LogGroupName: !Sub "/aws/apigateway/${AWS::StackName}-FraudFront-API-GW-AccessLogs"
 
   APIGWAccessLogsGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter


### PR DESCRIPTION
## Proposed changes

### What changed

Removed old prod log subscription

### Why did it change

Because the old endpoint is being decommissioned

