### PR TITLE
LIME-191: Adding basic alerting for fraud frontend

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.0",
+  "version": "1.4.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -581,6 +581,121 @@ Resources:
         SSEEnabled: true
         SSEType: KMS
 
+####################################################################
+#                                                                  #
+# Alerts                                                           #
+#                                                                  #
+####################################################################
+
+  FraudNoTaskCountAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: !Sub Fraud ${Environment} frontend no ECS service tasks
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AlarmTopicFraud
+      OKActions: []
+      InsufficientDataActions: []
+      MetricName: TaskCount
+      Namespace: ECS/ContainerInsights
+      Statistic: Average
+      Dimensions:
+        - Name: ClusterName
+          Value: !Ref FraudFrontEcsCluster
+      Period: 60
+      EvaluationPeriods: 2
+      DatapointsToAlarm: 2
+      Threshold: 1
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: breaching
+
+  FraudOnlyOneTaskCountAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: !Sub Fraud ${Environment} frontend below desired ECS service tasks
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AlarmTopicFraud
+      OKActions: []
+      InsufficientDataActions: []
+      MetricName: TaskCount
+      Namespace: ECS/ContainerInsights
+      Statistic: Average
+      Dimensions:
+        - Name: ClusterName
+          Value: !Ref FraudFrontEcsCluster
+      Period: 300
+      EvaluationPeriods: 3
+      DatapointsToAlarm: 3
+      Threshold: 2
+      ComparisonOperator: LessThanThreshold
+      TreatMissingData: breaching
+
+  Fraud5XXOnELB:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: !Sub Fraud ${Environment} frontend 5XX count
+      ActionsEnabled: true
+      AlarmActions:
+        - !Ref AlarmTopicFraud
+      OKActions: []
+      InsufficientDataActions: []
+      MetricName: HTTPCode_Target_5XX_Count
+      Namespace: AWS/ApplicationELB
+      Statistic: Sum
+      Dimensions:
+        - Name: TargetGroup
+          Value: !Ref LoadBalancerListenerTargetGroupECS
+        - Name: LoadBalancer
+          Value: !Ref LoadBalancer
+      Period: 60
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 5
+      Threshold: 1
+      ComparisonOperator: GreaterThanThreshold
+      TreatMissingData: notBreaching
+
+####################################################################
+#                                                                  #
+# Alarm setup                                                      #
+#                                                                  #
+####################################################################
+
+  AlarmTopicFraud:
+    Type: AWS::SNS::Topic
+    Metadata:
+      SamResourceId: AlarmTopicFraud
+  AlarmTopicSubscriptionPagerDutyFraud:
+    Type: AWS::SNS::Subscription
+    Properties:
+      TopicArn:
+        Ref: AlarmTopicFraud
+      Endpoint:
+        Fn::Sub: '{{resolve:ssm:/alerting/pagerduty-fraud/url}}'
+      Protocol: https
+    Metadata:
+      SamResourceId: AlarmTopicSubscriptionPagerDutyFraud
+  AlarmPublishToTopicPolicyFraud:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      Topics:
+        - Ref: AlarmTopicFraud
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: sns:Publish
+            Resource:
+              Ref: AlarmTopicFraud
+            Principal:
+              Service: cloudwatch.amazonaws.com
+            Condition:
+              ArnLike:
+                AWS:SourceArn:
+                  Fn::Sub: arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:*
+    Metadata:
+      SamResourceId: AlarmPublishToTopicPolicyFraud
+
 # Outputs
 
 Outputs:


### PR DESCRIPTION
## Proposed changes

### What changed

Added alerts for low and absent task counts and 500 errors

### Why did it change

So that we know if the frontend is experiencing any issues

