### PR TITLE
LIME-252 - Updating common-expresss version reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "cfenv": "1.2.4",
     "connect-dynamodb": "^2.0.5",
     "copyfiles": "2.4.1",
-    "di-ipv-cri-common-express": "alphagov/di-ipv-cri-common-express.git#v0.0.28",
+    "di-ipv-cri-common-express": "alphagov/di-ipv-cri-common-express.git#v0.0.38",
     "dotenv": "16.0.2",
     "express": "4.18.1",
     "express-async-errors": "3.1.1",


### PR DESCRIPTION
### What changed

Common-express version reference

### Why did it change

In order to Send a users ip_address to TXMA in logs
