### PR TITLE
LIME-698: Addressed issue where cfn tries to create log subscriptions before the associated groups

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -346,6 +346,7 @@ Resources:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
       FilterPattern: ""
       LogGroupName: !Sub "/aws/ecs/${AWS::StackName}-FraudFront-ECS"
+    DependsOn: ECSAccessLogsGroup
 
   ECSServiceTaskDefinition:
     Type: 'AWS::ECS::TaskDefinition'
@@ -525,6 +526,7 @@ Resources:
       DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
       FilterPattern: ""
       LogGroupName: !Sub "/aws/apigateway/${AWS::StackName}-FraudFront-API-GW-AccessLogs"
+    DependsOn: APIGWAccessLogsGroup
 
 # ECS Autoscaling
 # The number of pods will increase when the configured CPU utilization is breached for more than 3 minutes.


### PR DESCRIPTION
## Proposed changes

### What changed

Added depends on to the frontend subscription filters

### Why did it change

To force the the log groups to be created before the subscription filters that use them

